### PR TITLE
Filter out ANSI escape sequences ansi-color-filter output

### DIFF
--- a/isortify.el
+++ b/isortify.el
@@ -115,6 +115,7 @@ Show isort output, if isort exit abnormally and DISPLAY is t."
         (if (not (zerop (isortify-call-bin original-buffer tmpbuf)))
             (error "Isort failed, see %s buffer for details" (buffer-name tmpbuf))
           (with-current-buffer tmpbuf
+            (ansi-color-filter-region (point-min) (point-max))
             (copy-to-buffer original-buffer (point-min) (point-max)))
           (kill-buffer tmpbuf)
           (goto-char original-point)


### PR DESCRIPTION
When using `isortify` (with iPython as `python-shell-interpreter`), I have an ANSI escape sequence added to the end of the buffer: `^[[0m` (see screenshot)
<img width="410" alt="Screenshot 2022-11-08 at 20 50 32" src="https://user-images.githubusercontent.com/3234544/200663873-1a2c3690-825e-4b6c-8a8c-41292f45412a.png">

The proposed PR fixes the issue by using `ansi-color-filter output` to `tmpbuf`

One drawback of this PR is that the function `ansi-color-filter output`  is called even though ipython is not the python shell interpreter.

This is fixing #6 
